### PR TITLE
Feat fleet brush

### DIFF
--- a/src/__tests__/components/fleet/FleetAnalysisTabs.test.tsx
+++ b/src/__tests__/components/fleet/FleetAnalysisTabs.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import FleetAnalysisTabs from "@/components/fleet/FleetAnalysisTabs";
 import type { FleetSession } from "@/types/fleet";
+import type { LogEntry } from "@/lib/types";
 
 describe("FleetAnalysisTabs", () => {
   const mockSession: FleetSession = {
@@ -14,8 +15,8 @@ describe("FleetAnalysisTabs", () => {
         shipType: "Typhoon",
         damageDealt: 1500,
         damageTaken: 800,
-        repsGiven: 500,
-        repsTaken: 300,
+        repsGiven: 0,
+        repsTaken: 0,
         status: "active",
         logId: "log-1",
       },
@@ -96,5 +97,32 @@ describe("FleetAnalysisTabs", () => {
     fireEvent.click(screen.getByRole("button", { name: "Damage Dealt" }));
 
     expect(screen.queryByText("Fleet Participants")).not.toBeInTheDocument();
+  });
+
+  it("renders rep rows from rep entries even when participant totals are zero", () => {
+    const entries: LogEntry[] = [
+      {
+        id: "rep-1",
+        timestamp: new Date("2026-03-08T12:00:00.000Z"),
+        rawLine: "125 remote armor repaired to",
+        eventType: "rep-outgoing",
+        amount: 125,
+        fleetPilot: "Pilot One",
+      },
+    ];
+
+    render(
+      <FleetAnalysisTabs
+        sessionData={mockSession}
+        analysisReady={true}
+        entries={entries}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reps" }));
+
+    expect(screen.getByText("Pilot One")).toBeInTheDocument();
+    expect(screen.getByText("125")).toBeInTheDocument();
+    expect(screen.getByText("Total reps given")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/fleet/FleetOverviewTab.test.tsx
+++ b/src/__tests__/components/fleet/FleetOverviewTab.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import FleetOverviewTab from "@/components/fleet/FleetOverviewTab";
 import type { FleetCombatAnalysis } from "@/types/fleet";
+import type { LogEntry } from "@/lib/types";
 
 describe("FleetOverviewTab", () => {
   const mockFleetCombatAnalysis: FleetCombatAnalysis = {
@@ -111,5 +112,50 @@ describe("FleetOverviewTab", () => {
     render(<FleetOverviewTab fleetCombatAnalysis={mockFleetCombatAnalysis} />);
 
     expect(screen.getByText("Fleet Enemies")).toBeInTheDocument();
+  });
+
+  it("recomputes total stats from brush-windowed entries when provided", () => {
+    const entries: LogEntry[] = [
+      {
+        id: "1",
+        timestamp: new Date("2026-01-01T00:00:00.000Z"),
+        rawLine: "[combat]",
+        eventType: "damage-dealt",
+        amount: 1000,
+      },
+      {
+        id: "2",
+        timestamp: new Date("2026-01-01T00:00:10.000Z"),
+        rawLine: "[combat]",
+        eventType: "damage-received",
+        amount: 500,
+      },
+      {
+        id: "3",
+        timestamp: new Date("2026-01-01T00:00:20.000Z"),
+        rawLine: "[combat]",
+        eventType: "rep-outgoing",
+        amount: 200,
+      },
+      {
+        id: "4",
+        timestamp: new Date("2026-01-01T00:05:00.000Z"),
+        rawLine: "[combat]",
+        eventType: "damage-dealt",
+        amount: 50000,
+      },
+    ];
+
+    render(
+      <FleetOverviewTab
+        fleetCombatAnalysis={mockFleetCombatAnalysis}
+        entries={entries}
+        brushWindow={{ start: new Date("2026-01-01T00:00:00.000Z"), end: new Date("2026-01-01T00:00:30.000Z") }}
+      />,);
+
+    expect(screen.getByText("Showing zoomed selection")).toBeInTheDocument();
+    expect(screen.getByText("1.0K ISK")).toBeInTheDocument();
+    expect(screen.getByText("500 ISK")).toBeInTheDocument();
+    expect(screen.getByText("200 HP")).toBeInTheDocument();
   });
 });

--- a/src/__tests__/integration/fleetBrushFiltering.test.ts
+++ b/src/__tests__/integration/fleetBrushFiltering.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import type { LogEntry } from "@/lib/types";
+import { analyzeDamageDealt } from "@/lib/analysis/damageDealt";
+import { analyzeDamageTaken } from "@/lib/analysis/damageTaken";
+
+function makeEntry(
+  id: string,
+  offsetMs: number,
+  eventType: "damage-dealt" | "damage-received",
+  amount: number,
+): LogEntry {
+  const base = Date.parse("2026-01-01T00:00:00.000Z");
+  return {
+    id,
+    rawLine: "[combat]",
+    timestamp: new Date(base + offsetMs),
+    eventType,
+    amount,
+  } as LogEntry;
+}
+
+describe("fleet brush filtering", () => {
+  const allEntries: LogEntry[] = [
+    makeEntry("dealt-0", 0, "damage-dealt", 100),
+    makeEntry("received-0", 0, "damage-received", 10),
+    makeEntry("dealt-60", 60_000, "damage-dealt", 200),
+    makeEntry("received-60", 60_000, "damage-received", 20),
+    makeEntry("dealt-120", 120_000, "damage-dealt", 300),
+    makeEntry("received-120", 120_000, "damage-received", 30),
+    makeEntry("dealt-180", 180_000, "damage-dealt", 400),
+    makeEntry("received-180", 180_000, "damage-received", 40),
+    makeEntry("dealt-240", 240_000, "damage-dealt", 500),
+    makeEntry("received-240", 240_000, "damage-received", 50),
+    makeEntry("dealt-300", 300_000, "damage-dealt", 600),
+    makeEntry("received-300", 300_000, "damage-received", 60),
+  ];
+
+  const brushWindow = {
+    start: new Date("2026-01-01T00:01:30.000Z"),
+    end: new Date("2026-01-01T00:03:30.000Z"),
+  };
+
+  const applyBrushFilter = (
+    entries: LogEntry[],
+    window: { start: Date; end: Date } | null,
+  ) => {
+    if (window === null) return entries;
+    return entries.filter(
+      (e) => e.timestamp >= window.start && e.timestamp <= window.end,
+    );
+  };
+
+  const windowedEntries = applyBrushFilter(allEntries, brushWindow);
+
+  it("filters both damage-dealt and damage-received analyses to the brush window", () => {
+    const dealt = analyzeDamageDealt(windowedEntries);
+    const taken = analyzeDamageTaken(windowedEntries);
+
+    expect(dealt.totalDamageDealt).toBe(700);
+    expect(dealt.totalHits).toBe(2);
+
+    expect(taken.totalDamageReceived).toBe(70);
+    expect(taken.totalIncomingHits).toBe(2);
+  });
+
+  it("returns all entries when brush window is null", () => {
+    const allWindowEntries = applyBrushFilter(allEntries, null);
+    const allDealt = analyzeDamageDealt(allWindowEntries);
+    const allTaken = analyzeDamageTaken(allWindowEntries);
+
+    expect(allDealt.totalDamageDealt).toBe(2100);
+    expect(allDealt.totalHits).toBe(6);
+
+    expect(allTaken.totalDamageReceived).toBe(210);
+    expect(allTaken.totalIncomingHits).toBe(6);
+  });
+});

--- a/src/components/fleet/FleetAnalysisTabs.tsx
+++ b/src/components/fleet/FleetAnalysisTabs.tsx
@@ -109,15 +109,19 @@ function RepsTab({
   const windowedEntries = useMemo(() => {
     if (!brushWindow) return entries;
     return entries.filter(
-      (e) =>
-        e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
+      (e) => e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
     );
   }, [entries, brushWindow]);
 
   const pilotStats = useMemo(() => {
     const byPilot = new Map<
       string,
-      { pilotName: string; shipType: string; repsGiven: number; repsTaken: number }
+      {
+        pilotName: string;
+        shipType: string;
+        repsGiven: number;
+        repsTaken: number;
+      }
     >();
     const lookupByPilot = new Map(
       participants.map((p) => [p.pilotName, p.shipType]),
@@ -427,9 +431,8 @@ export default function FleetAnalysisTabs({
   const [activeTab, setActiveTab] = useState<TabKey>("overview");
   const [brushWindow, setBrushWindow] = useState<BrushWindow | null>(null);
   const [brushResetKey, setBrushResetKey] = useState(0);
-  const [initialBrushWindow, setInitialBrushWindow] = useState<BrushWindow | null>(
-    null,
-  );
+  const [initialBrushWindow, setInitialBrushWindow] =
+    useState<BrushWindow | null>(null);
 
   const handleBrushChange = (start: Date, end: Date) => {
     setBrushWindow({ start, end });

--- a/src/components/fleet/FleetAnalysisTabs.tsx
+++ b/src/components/fleet/FleetAnalysisTabs.tsx
@@ -14,6 +14,7 @@ import {
 import FleetOverviewTab from "./FleetOverviewTab";
 import FleetDamageDealtContent from "./FleetDamageDealtContent";
 import FleetDamageTakenContent from "./FleetDamageTakenContent";
+import Button from "@/components/ui/Button";
 import {
   FleetSession,
   FleetCombatAnalysis,
@@ -28,6 +29,11 @@ interface FleetAnalysisTabsProps {
   /** Merged LogEntry array from all uploaded pilot logs (timestamps already revived as Dates). */
   entries?: LogEntry[];
 }
+
+type BrushWindow = {
+  start: Date;
+  end: Date;
+};
 
 // ── Colour palette for per-pilot lines (re-used) ───────────────────────────────
 
@@ -95,19 +101,75 @@ function RepsTab({
   participants,
   totalGiven,
   entries,
+  brushWindow,
 }: {
   participants: FleetParticipant[];
   totalGiven: number;
   entries: LogEntry[];
+  brushWindow?: BrushWindow | null;
 }) {
-  const withReps = participants.filter(
-    (p) => p.repsGiven > 0 || p.repsTaken > 0,
-  );
-  const sorted = [...withReps].sort((a, b) => b.repsGiven - a.repsGiven);
+  const windowedEntries = useMemo(() => {
+    if (!brushWindow) return entries;
+    return entries.filter(
+      (e) =>
+        e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
+    );
+  }, [entries, brushWindow]);
+
+  const pilotStats = useMemo(() => {
+    const byPilot = new Map<
+      string,
+      { pilotName: string; shipType: string; repsGiven: number; repsTaken: number }
+    >();
+    const lookupByPilot = new Map(
+      participants.map((p) => [p.pilotName, p.shipType]),
+    );
+
+    const addPilot = (name: string): void => {
+      if (!byPilot.has(name)) {
+        byPilot.set(name, {
+          pilotName: name,
+          shipType: lookupByPilot.get(name) || "Unknown",
+          repsGiven: 0,
+          repsTaken: 0,
+        });
+      }
+    };
+
+    for (const entry of windowedEntries) {
+      const amount = entry.amount ?? 0;
+      if (entry.eventType === "rep-outgoing") {
+        const pilot = entry.fleetPilot ?? entry.pilotName ?? "Unknown";
+        addPilot(pilot);
+        byPilot.get(pilot)!.repsGiven += amount;
+      }
+
+      if (entry.eventType === "rep-received") {
+        const pilot = entry.fleetPilot ?? entry.pilotName ?? "Unknown";
+        addPilot(pilot);
+        byPilot.get(pilot)!.repsTaken += amount;
+      }
+    }
+
+    const repRows = [...byPilot.values()].filter(
+      (p) => p.repsGiven > 0 || p.repsTaken > 0,
+    );
+    const sorted = repRows.sort((a, b) => b.repsGiven - a.repsGiven);
+
+    const computedTotalGiven = sorted.reduce((sum, p) => sum + p.repsGiven, 0);
+    return { sorted, computedTotalGiven };
+  }, [windowedEntries, participants]);
+
+  const { sorted, computedTotalGiven } = pilotStats;
+
+  void totalGiven;
+
+  // Preserve chart behaviour on full timeline for now; Reps analysis stays zoom-aware.
   const { data: repsChartData, pilots: repsPilots } = useMemo(
     () => computePerPilotReps(entries),
     [entries],
   );
+
   if (sorted.length === 0) {
     return (
       <p className="text-text-muted text-center py-12">
@@ -185,7 +247,8 @@ function RepsTab({
         </div>
       )}
       {sorted.map((p) => {
-        const pct = totalGiven > 0 ? (p.repsGiven / totalGiven) * 100 : 0;
+        const pct =
+          computedTotalGiven > 0 ? (p.repsGiven / computedTotalGiven) * 100 : 0;
         return (
           <div
             key={p.pilotName}
@@ -226,7 +289,7 @@ function RepsTab({
       })}
       <div className="flex justify-between text-xs text-text-muted pt-1 px-1">
         <span>Total reps given</span>
-        <span className="font-mono">{formatNumber(totalGiven)}</span>
+        <span className="font-mono">{formatNumber(computedTotalGiven)}</span>
       </div>
     </div>
   );
@@ -366,6 +429,22 @@ export default function FleetAnalysisTabs({
   entries = [],
 }: FleetAnalysisTabsProps) {
   const [activeTab, setActiveTab] = useState<TabKey>("overview");
+  const [brushWindow, setBrushWindow] = useState<BrushWindow | null>(null);
+  const [brushResetKey, setBrushResetKey] = useState(0);
+  const [initialBrushWindow, setInitialBrushWindow] = useState<BrushWindow | null>(
+    null,
+  );
+
+  const handleBrushChange = (start: Date, end: Date) => {
+    setBrushWindow({ start, end });
+    setInitialBrushWindow({ start, end });
+  };
+
+  const handleResetBrush = () => {
+    setBrushWindow(null);
+    setInitialBrushWindow(null);
+    setBrushResetKey((v) => v + 1);
+  };
 
   const fleetCombatAnalysis: FleetCombatAnalysis = useMemo(
     () => ({
@@ -399,38 +478,66 @@ export default function FleetAnalysisTabs({
       )}
 
       {/* Tab Navigation */}
-      <div className="flex gap-2 border-b border-border flex-wrap">
-        {TABS.map((tab) => (
-          <button
-            key={tab.key}
-            className={`px-4 py-2 ${
-              activeTab === tab.key
-                ? "text-text-primary border-b-2 border-accent"
-                : "text-text-muted hover:text-text-primary"
-            }`}
-            onClick={() => setActiveTab(tab.key)}
+      <div className="flex gap-2 border-b border-border flex-wrap justify-between">
+        <div className="flex gap-2 flex-wrap">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              className={`px-4 py-2 ${
+                activeTab === tab.key
+                  ? "text-text-primary border-b-2 border-accent"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+              onClick={() => setActiveTab(tab.key)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        {brushWindow !== null && (
+          <Button
+            variant="secondary"
+            onClick={handleResetBrush}
+            className="text-xs mt-2"
           >
-            {tab.label}
-          </button>
-        ))}
+            {`Zoomed: ${formatLogTime(brushWindow.start)} – ${formatLogTime(brushWindow.end)} · Reset Zoom`}
+          </Button>
+        )}
       </div>
 
       {/* Tab Content */}
       <div>
         {activeTab === "overview" && (
-          <FleetOverviewTab fleetCombatAnalysis={fleetCombatAnalysis} />
+          <FleetOverviewTab
+            fleetCombatAnalysis={fleetCombatAnalysis}
+            entries={entries}
+            brushWindow={brushWindow}
+          />
         )}
         {activeTab === "damage-dealt" && (
-          <FleetDamageDealtContent entries={entries} />
+          <FleetDamageDealtContent
+            entries={entries}
+            brushWindow={brushWindow}
+            onBrushChange={handleBrushChange}
+            brushResetKey={brushResetKey}
+            initialBrushWindow={initialBrushWindow}
+          />
         )}
         {activeTab === "damage-taken" && (
-          <FleetDamageTakenContent entries={entries} />
+          <FleetDamageTakenContent
+            entries={entries}
+            brushWindow={brushWindow}
+            onBrushChange={handleBrushChange}
+            brushResetKey={brushResetKey}
+            initialBrushWindow={initialBrushWindow}
+          />
         )}
         {activeTab === "reps" && (
           <RepsTab
             participants={fleetCombatAnalysis.participants}
             totalGiven={fleetCombatAnalysis.totalRepsGiven}
             entries={entries}
+            brushWindow={brushWindow}
           />
         )}
         {activeTab === "cap-pressure" && (

--- a/src/components/fleet/FleetAnalysisTabs.tsx
+++ b/src/components/fleet/FleetAnalysisTabs.tsx
@@ -99,12 +99,10 @@ function computePerPilotReps(
 
 function RepsTab({
   participants,
-  totalGiven,
   entries,
   brushWindow,
 }: {
   participants: FleetParticipant[];
-  totalGiven: number;
   entries: LogEntry[];
   brushWindow?: BrushWindow | null;
 }) {
@@ -161,8 +159,6 @@ function RepsTab({
   }, [windowedEntries, participants]);
 
   const { sorted, computedTotalGiven } = pilotStats;
-
-  void totalGiven;
 
   // Preserve chart behaviour on full timeline for now; Reps analysis stays zoom-aware.
   const { data: repsChartData, pilots: repsPilots } = useMemo(
@@ -535,7 +531,6 @@ export default function FleetAnalysisTabs({
         {activeTab === "reps" && (
           <RepsTab
             participants={fleetCombatAnalysis.participants}
-            totalGiven={fleetCombatAnalysis.totalRepsGiven}
             entries={entries}
             brushWindow={brushWindow}
           />

--- a/src/components/fleet/FleetDamageDealtContent.tsx
+++ b/src/components/fleet/FleetDamageDealtContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Sword } from "lucide-react";
 import {
   ComposedChart,
@@ -11,6 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
   CartesianGrid,
+  Brush,
 } from "recharts";
 import Panel from "@/components/ui/Panel";
 import StatCard from "@/components/dashboard/StatCard";
@@ -40,7 +41,7 @@ const PILOT_COLORS = [
 function computePerPilotDps(
   entries: LogEntry[],
   bucketSecs = 30,
-): { data: Record<string, unknown>[]; pilots: string[] } {
+): { data: Array<{ label: string; timestampMs: number; [pilot: string]: number | string }>; pilots: string[] } {
   const dmgEntries = entries.filter((e) => e.eventType === "damage-dealt");
   if (dmgEntries.length === 0) return { data: [], pilots: [] };
 
@@ -73,6 +74,7 @@ function computePerPilotDps(
     const t = tMin + i * bucketMs;
     const point: Record<string, unknown> = {
       label: formatLogTime(t),
+      timestampMs: t,
     };
     const m = buckets.get(t);
     for (const pilot of pilots) {
@@ -86,12 +88,66 @@ function computePerPilotDps(
 
 interface FleetPilotDpsChartProps {
   entries: LogEntry[];
+  onBrushChange?: (start: Date, end: Date) => void;
+  brushResetKey?: number;
+  initialBrushWindow?: { start: Date; end: Date } | null;
 }
 
-function FleetPilotDpsChart({ entries }: FleetPilotDpsChartProps) {
+function FleetPilotDpsChart({
+  entries,
+  onBrushChange,
+  brushResetKey,
+  initialBrushWindow,
+}: FleetPilotDpsChartProps) {
   const { data, pilots } = useMemo(
     () => computePerPilotDps(entries),
     [entries],
+  );
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const brushIndices = useMemo(() => {
+    if (!initialBrushWindow || data.length === 0) return null;
+
+    const startTs = initialBrushWindow.start.getTime();
+    const endTs = initialBrushWindow.end.getTime();
+
+    const findClosestIndex = (targetTs: number) => {
+      let bestIndex = 0;
+      let bestDiff = Infinity;
+
+      for (let i = 0; i < data.length; i++) {
+        const point = data[i];
+        if (!point) continue;
+        const diff = Math.abs((point.timestampMs as number) - targetTs);
+        if (diff < bestDiff) {
+          bestDiff = diff;
+          bestIndex = i;
+        }
+      }
+      return bestIndex;
+    };
+
+    const startIndex = findClosestIndex(startTs);
+    const endIndex = findClosestIndex(endTs);
+    return {
+      startIndex: Math.min(startIndex, endIndex),
+      endIndex: Math.max(startIndex, endIndex),
+    };
+  }, [initialBrushWindow, data]);
+
+  const handleBrushChange = useCallback(
+    (brushData: { startIndex?: number; endIndex?: number }) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        const { startIndex, endIndex } = brushData;
+        if (startIndex == null || endIndex == null) return;
+        const startTs = data[startIndex]?.timestampMs;
+        const endTs = data[endIndex]?.timestampMs;
+        if (startTs == null || endTs == null) return;
+        onBrushChange?.(new Date(startTs), new Date(endTs));
+      }, 300);
+    },
+    [data, onBrushChange],
   );
 
   if (data.length === 0) return null;
@@ -143,6 +199,17 @@ function FleetPilotDpsChart({ entries }: FleetPilotDpsChartProps) {
             activeDot={{ r: 4 }}
           />
         ))}
+        <Brush
+          key={brushResetKey}
+          dataKey="timestampMs"
+          height={28}
+          stroke="#e53e3e"
+          fill="#0d0d0d"
+          travellerWidth={8}
+          tickFormatter={(ts: number) => formatLogTime(ts)}
+          onChange={handleBrushChange}
+          {...(brushIndices ?? {})}
+        />
       </ComposedChart>
     </ResponsiveContainer>
   );
@@ -401,12 +468,40 @@ function WeaponTable({
 
 interface FleetDamageDealtContentProps {
   entries: LogEntry[];
+  brushWindow?: {
+    start: Date;
+    end: Date;
+  } | null;
+  onBrushChange?: (start: Date, end: Date) => void;
+  brushResetKey?: number;
+  initialBrushWindow?: {
+    start: Date;
+    end: Date;
+  } | null;
 }
 
 export default function FleetDamageDealtContent({
   entries,
+  brushWindow,
+  onBrushChange,
+  brushResetKey,
+  initialBrushWindow,
 }: FleetDamageDealtContentProps) {
-  const analysis = useMemo(() => analyzeDamageDealt(entries), [entries]);
+  const windowedEntries = useMemo(
+    () =>
+      brushWindow
+        ? entries.filter(
+            (e) =>
+              e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
+          )
+        : entries,
+    [entries, brushWindow],
+  );
+
+  const analysis = useMemo(
+    () => analyzeDamageDealt(windowedEntries),
+    [windowedEntries],
+  );
 
   // NOTE: engagement table / zoom state removed for Phase 05 matrix drill-down.
 
@@ -432,6 +527,11 @@ export default function FleetDamageDealtContent({
   return (
     <div className="space-y-6">
       {/* Stat cards */}
+      {brushWindow && (
+        <p className="font-mono text-xs uppercase tracking-widest text-text-muted">
+          Showing brush selection
+        </p>
+      )}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
         <StatCard label="Best Single Hit" value={bestHit} variant="gold" />
         <StatCard label="Worst Hit" value={worstHit} variant="default" />
@@ -454,12 +554,17 @@ export default function FleetDamageDealtContent({
 
       {/* Per-pilot DPS chart */}
       <Panel title="DPS OVER TIME — PER PILOT (30s buckets)">
-        <FleetPilotDpsChart entries={entries} />
+        <FleetPilotDpsChart
+          entries={entries}
+          onBrushChange={onBrushChange}
+          brushResetKey={brushResetKey}
+          initialBrushWindow={initialBrushWindow}
+        />
       </Panel>
 
       {/* Drill-down: fleet pilot ↔ target */}
       <Panel title="DAMAGE MATRIX — FLEET PILOTS vs TARGETS">
-        <DamageDealtMatrix entries={entries} />
+        <DamageDealtMatrix entries={windowedEntries} />
       </Panel>
 
       {/* Weapons & Drones (no hit quality) */}

--- a/src/components/fleet/FleetDamageDealtContent.tsx
+++ b/src/components/fleet/FleetDamageDealtContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sword } from "lucide-react";
 import {
   ComposedChart,
@@ -149,6 +149,14 @@ function FleetPilotDpsChart({
     },
     [data, onBrushChange],
   );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
 
   if (data.length === 0) return null;
 

--- a/src/components/fleet/FleetDamageDealtContent.tsx
+++ b/src/components/fleet/FleetDamageDealtContent.tsx
@@ -41,7 +41,14 @@ const PILOT_COLORS = [
 function computePerPilotDps(
   entries: LogEntry[],
   bucketSecs = 30,
-): { data: Array<{ label: string; timestampMs: number; [pilot: string]: number | string }>; pilots: string[] } {
+): {
+  data: Array<{
+    label: string;
+    timestampMs: number;
+    [pilot: string]: number | string;
+  }>;
+  pilots: string[];
+} {
   const dmgEntries = entries.filter((e) => e.eventType === "damage-dealt");
   if (dmgEntries.length === 0) return { data: [], pilots: [] };
 
@@ -500,7 +507,8 @@ export default function FleetDamageDealtContent({
       brushWindow
         ? entries.filter(
             (e) =>
-              e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
+              e.timestamp >= brushWindow.start &&
+              e.timestamp <= brushWindow.end,
           )
         : entries,
     [entries, brushWindow],

--- a/src/components/fleet/FleetDamageTakenContent.tsx
+++ b/src/components/fleet/FleetDamageTakenContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ShieldAlert } from "lucide-react";
 import Panel from "@/components/ui/Panel";
 import Badge from "@/components/ui/Badge";
@@ -162,6 +162,14 @@ function FleetPilotDamageTakenChart({
     },
     [data, onBrushChange],
   );
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
 
   if (!data || data.length === 0 || pilots.length === 0) {
     return (

--- a/src/components/fleet/FleetDamageTakenContent.tsx
+++ b/src/components/fleet/FleetDamageTakenContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { ShieldAlert } from "lucide-react";
 import Panel from "@/components/ui/Panel";
 import Badge from "@/components/ui/Badge";
@@ -13,6 +13,7 @@ import {
   XAxis,
   YAxis,
   Tooltip,
+  Brush,
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
@@ -98,10 +99,68 @@ function computePerPilotDamageTaken(entries: LogEntry[]) {
   return { pilots, data };
 }
 
-function FleetPilotDamageTakenChart({ entries }: { entries: LogEntry[] }) {
+interface FleetPilotDamageTakenChartProps {
+  entries: LogEntry[];
+  onBrushChange?: (start: Date, end: Date) => void;
+  brushResetKey?: number;
+  initialBrushWindow?: { start: Date; end: Date } | null;
+}
+
+function FleetPilotDamageTakenChart({
+  entries,
+  onBrushChange,
+  brushResetKey,
+  initialBrushWindow,
+}: FleetPilotDamageTakenChartProps) {
   const { pilots, data } = useMemo(
     () => computePerPilotDamageTaken(entries),
     [entries],
+  );
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const brushIndices = useMemo(() => {
+    if (!initialBrushWindow || data.length === 0) return null;
+
+    const startTs = initialBrushWindow.start.getTime();
+    const endTs = initialBrushWindow.end.getTime();
+
+    const findClosestIndex = (targetTs: number) => {
+      let bestIndex = 0;
+      let bestDiff = Infinity;
+
+      for (let i = 0; i < data.length; i++) {
+        const point = data[i];
+        if (!point) continue;
+        const diff = Math.abs((point.timestampMs as number) - targetTs);
+        if (diff < bestDiff) {
+          bestDiff = diff;
+          bestIndex = i;
+        }
+      }
+      return bestIndex;
+    };
+
+    const startIndex = findClosestIndex(startTs);
+    const endIndex = findClosestIndex(endTs);
+    return {
+      startIndex: Math.min(startIndex, endIndex),
+      endIndex: Math.max(startIndex, endIndex),
+    };
+  }, [initialBrushWindow, data]);
+
+  const handleBrushChange = useCallback(
+    (brushData: { startIndex?: number; endIndex?: number }) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        const { startIndex, endIndex } = brushData;
+        if (startIndex == null || endIndex == null) return;
+        const startTs = data[startIndex]?.timestampMs;
+        const endTs = data[endIndex]?.timestampMs;
+        if (startTs == null || endTs == null) return;
+        onBrushChange?.(new Date(startTs), new Date(endTs));
+      }, 300);
+    },
+    [data, onBrushChange],
   );
 
   if (!data || data.length === 0 || pilots.length === 0) {
@@ -184,6 +243,17 @@ function FleetPilotDamageTakenChart({ entries }: { entries: LogEntry[] }) {
               animationDuration={600}
             />
           ))}
+          <Brush
+            key={brushResetKey}
+            dataKey="timestampMs"
+            height={28}
+            stroke="#e53e3e"
+            fill="#0d0d0d"
+            travellerWidth={8}
+            tickFormatter={(ts: number) => formatLogTime(ts)}
+            onChange={handleBrushChange}
+            {...(brushIndices ?? {})}
+          />
         </ComposedChart>
       </ResponsiveContainer>
     </div>
@@ -490,11 +560,26 @@ function RepTable({
 
 interface FleetDamageTakenContentProps {
   entries: LogEntry[];
+  brushWindow?: {
+    start: Date;
+    end: Date;
+  } | null;
+  onBrushChange?: (start: Date, end: Date) => void;
+  brushResetKey?: number;
+  initialBrushWindow?: {
+    start: Date;
+    end: Date;
+  } | null;
 }
 
 export default function FleetDamageTakenContent({
   entries,
+  brushWindow,
+  onBrushChange,
+  brushResetKey,
+  initialBrushWindow,
 }: FleetDamageTakenContentProps) {
+  void brushWindow;
   const [hideNpcs, setHideNpcs] = useState(false);
 
   const filteredEntries = useMemo(
@@ -543,7 +628,12 @@ export default function FleetDamageTakenContent({
 
       {/* Per-pilot incoming DPS chart */}
       <Panel title="INCOMING DPS — PER PILOT (30s buckets)">
-        <FleetPilotDamageTakenChart entries={filteredEntries} />
+        <FleetPilotDamageTakenChart
+          entries={filteredEntries}
+          onBrushChange={onBrushChange}
+          brushResetKey={brushResetKey}
+          initialBrushWindow={initialBrushWindow}
+        />
       </Panel>
 
       {/* Peak DPS */}

--- a/src/components/fleet/FleetDamageTakenContent.tsx
+++ b/src/components/fleet/FleetDamageTakenContent.tsx
@@ -579,7 +579,6 @@ export default function FleetDamageTakenContent({
   brushResetKey,
   initialBrushWindow,
 }: FleetDamageTakenContentProps) {
-  void brushWindow;
   const [hideNpcs, setHideNpcs] = useState(false);
 
   const filteredEntries = useMemo(
@@ -587,14 +586,25 @@ export default function FleetDamageTakenContent({
     [entries, hideNpcs],
   );
 
+  const windowedEntries = useMemo(
+    () =>
+      brushWindow
+        ? filteredEntries.filter(
+            (e) =>
+              e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
+          )
+        : filteredEntries,
+    [brushWindow, filteredEntries],
+  );
+
   const damageAnalysis = useMemo(
-    () => analyzeDamageTaken(filteredEntries),
-    [filteredEntries],
+    () => analyzeDamageTaken(windowedEntries),
+    [windowedEntries],
   );
 
   const repAnalysis = useMemo(
-    () => analyzeReps(filteredEntries),
-    [filteredEntries],
+    () => analyzeReps(windowedEntries),
+    [windowedEntries],
   );
 
   if (damageAnalysis.totalIncomingHits === 0) {
@@ -637,6 +647,11 @@ export default function FleetDamageTakenContent({
       </Panel>
 
       {/* Peak DPS */}
+      {brushWindow && (
+        <p className="font-mono text-xs uppercase tracking-widest text-text-muted">
+          Showing brush selection
+        </p>
+      )}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <StatCard
           label="PEAK DPS (10s)"
@@ -660,7 +675,7 @@ export default function FleetDamageTakenContent({
 
       {/* Per-pilot damage taken bars */}
       <Panel title="DAMAGE TAKEN — PER PILOT">
-        <PilotDamageTakenBars entries={filteredEntries} />
+        <PilotDamageTakenBars entries={windowedEntries} />
       </Panel>
 
       {/* Reps */}

--- a/src/components/fleet/FleetDamageTakenContent.tsx
+++ b/src/components/fleet/FleetDamageTakenContent.tsx
@@ -53,7 +53,10 @@ const PILOT_COLORS = [
 function computePerPilotDamageTaken(entries: LogEntry[]) {
   const damageEvents = entries.filter((e) => e.eventType === "damage-received");
   if (damageEvents.length === 0)
-    return { pilots: [] as string[], data: [] as Record<string, number | Date | string>[] };
+    return {
+      pilots: [] as string[],
+      data: [] as Record<string, number | Date | string>[],
+    };
 
   const bucketMs = 30 * 1000; // 30s buckets
   const tsSorted = damageEvents
@@ -215,7 +218,15 @@ function FleetPilotDamageTakenChart({
             width={56}
           />
           <Tooltip
-            content={({ active, payload }: { active?: boolean; payload?: ReadonlyArray<{ payload: Record<string, number | Date | string> }> }) => {
+            content={({
+              active,
+              payload,
+            }: {
+              active?: boolean;
+              payload?: ReadonlyArray<{
+                payload: Record<string, number | Date | string>;
+              }>;
+            }) => {
               if (!active || !payload?.length) return null;
               const point = payload[0]?.payload;
               return (
@@ -599,7 +610,8 @@ export default function FleetDamageTakenContent({
       brushWindow
         ? filteredEntries.filter(
             (e) =>
-              e.timestamp >= brushWindow.start && e.timestamp <= brushWindow.end,
+              e.timestamp >= brushWindow.start &&
+              e.timestamp <= brushWindow.end,
           )
         : filteredEntries,
     [brushWindow, filteredEntries],

--- a/src/components/fleet/FleetOverviewTab.tsx
+++ b/src/components/fleet/FleetOverviewTab.tsx
@@ -5,28 +5,72 @@ import FleetParticipantsTable from "./FleetParticipantsTable";
 import FleetEnemiesTable from "./FleetEnemiesTable";
 import { FleetCombatAnalysis } from "@/types/fleet";
 import { formatNumber, formatDuration } from "@/lib/utils";
+import type { LogEntry } from "@/lib/types";
+import { useMemo } from "react";
 
 interface FleetOverviewTabProps {
   fleetCombatAnalysis: FleetCombatAnalysis;
+  entries?: LogEntry[];
+  brushWindow?: {
+    start: Date;
+    end: Date;
+  } | null;
 }
 
 export default function FleetOverviewTab({
   fleetCombatAnalysis,
+  entries,
+  brushWindow,
 }: FleetOverviewTabProps) {
-  const {
-    totalDamageDealt,
-    totalDamageTaken,
-    totalRepsGiven,
-    participants,
-    enemies,
-    fightDuration,
-  } = fleetCombatAnalysis;
+  const scopedTotals = useMemo(() => {
+    if (!brushWindow || !entries || entries.length === 0) {
+      return {
+        totalDamageDealt: fleetCombatAnalysis.totalDamageDealt,
+        totalDamageTaken: fleetCombatAnalysis.totalDamageTaken,
+        totalRepsGiven: fleetCombatAnalysis.totalRepsGiven,
+      };
+    }
+
+    const windowedEntries = entries.filter(
+      (entry) =>
+        entry.timestamp >= brushWindow.start && entry.timestamp <= brushWindow.end,
+    );
+
+    const totalDamageDealt = windowedEntries
+      .filter((entry) => entry.eventType === "damage-dealt")
+      .reduce((sum, entry) => sum + (entry.amount ?? 0), 0);
+
+    const totalDamageTaken = windowedEntries
+      .filter((entry) => entry.eventType === "damage-received")
+      .reduce((sum, entry) => sum + (entry.amount ?? 0), 0);
+
+    const totalRepsGiven = windowedEntries
+      .filter((entry) => entry.eventType === "rep-outgoing")
+      .reduce((sum, entry) => sum + (entry.amount ?? 0), 0);
+
+    return {
+      totalDamageDealt,
+      totalDamageTaken,
+      totalRepsGiven,
+    };
+  }, [
+    entries,
+    brushWindow,
+    fleetCombatAnalysis.totalDamageDealt,
+    fleetCombatAnalysis.totalDamageTaken,
+    fleetCombatAnalysis.totalRepsGiven,
+  ]);
+
+  const { participants, enemies, fightDuration } = fleetCombatAnalysis;
 
   const enemyCount = enemies.length;
   const enemyKills = enemies.reduce((sum, enemy) => sum + enemy.kills, 0);
 
   return (
     <div className="space-y-6">
+      {brushWindow ? (
+        <p className="text-text-muted text-xs font-medium">Showing zoomed selection</p>
+      ) : null}
       {/* Metric Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <StatCard
@@ -35,15 +79,15 @@ export default function FleetOverviewTab({
         />
         <StatCard
           label="Total Damage Dealt"
-          value={`${formatNumber(totalDamageDealt)} ISK`}
+          value={`${formatNumber(scopedTotals.totalDamageDealt)} ISK`}
         />
         <StatCard
           label="Total Damage Received"
-          value={`${formatNumber(totalDamageTaken)} ISK`}
+          value={`${formatNumber(scopedTotals.totalDamageTaken)} ISK`}
         />
         <StatCard
           label="Total Reps Given"
-          value={`${formatNumber(totalRepsGiven)} HP`}
+          value={`${formatNumber(scopedTotals.totalRepsGiven)} HP`}
         />
         <StatCard label="Enemy Count" value={`${enemyCount} enemies`} />
         <StatCard label="Enemy Kills" value={`${enemyKills} killed`} />


### PR DESCRIPTION
This pull request introduces a brush-based zoom feature to the fleet combat analysis UI, allowing users to select a time window on charts and view recalculated stats and tables for that selection. The changes include new UI elements, logic for filtering entries based on the brush window, and updates to test coverage to ensure correct behavior. The implementation is primarily focused on the `FleetAnalysisTabs`, `FleetDamageDealtContent`, and related components.

**Brush-based zoom and filtering enhancements:**

* Added brush-based zoom functionality to the fleet analysis charts, enabling users to select a time window and view recalculated stats for that selection. The brush state is managed in `FleetAnalysisTabs`, and passed to relevant tab content components. [[1]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bR432-R447) [[2]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R91-R151) [[3]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R471-R504)
* Updated `FleetDamageDealtContent` and `FleetPilotDpsChart` to filter entries and recompute stats based on the selected brush window, including UI feedback for zoomed selection and resetting the brush. [[1]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R202-R212) [[2]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R530-R534) [[3]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bL402-R482)
* Modified `RepsTab` to recalculate per-pilot rep stats based on the brush window, ensuring that rep rows and totals reflect the filtered selection. [[1]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bR104-R172) [[2]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bL188-R251) [[3]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bL229-R292)

**Testing and validation:**

* Added and updated tests to verify that stats and rows are correctly recomputed when a brush window is applied, including integration tests for filtering and recalculation logic. [[1]](diffhunk://#diff-e27737afe1aa197029a182dc5ec61d10bec2e0a56a8f7d689800bd55eed36388R116-R160) [[2]](diffhunk://#diff-b260c26245dee56762776fe4acb6a5eb8656632da1718ef6e864577b3643ea8bR1-R77) [[3]](diffhunk://#diff-180e579beee1ab4b8ddfff6a8ecfa520041bcc866bae92022b5e7a1970315be3R101-R127)

**Codebase improvements and refactoring:**

* Refactored chart and filtering logic to improve maintainability, including adding type definitions and optimizing brush index calculations for accurate selection. [[1]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05L43-R44) [[2]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R77) [[3]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R14)

These changes collectively improve the user experience by enabling detailed drill-down and zoom functionality in fleet combat analysis.

---

**References:**  
[[1]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bR432-R447) [[2]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R91-R151) [[3]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R471-R504) [[4]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R202-R212) [[5]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R530-R534) [[6]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bL402-R482) [[7]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bR104-R172) [[8]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bL188-R251) [[9]](diffhunk://#diff-9ba52b315668c97e0bfe45d6a9842908f24250982beaa7e293190bb69fd9501bL229-R292) [[10]](diffhunk://#diff-e27737afe1aa197029a182dc5ec61d10bec2e0a56a8f7d689800bd55eed36388R116-R160) [[11]](diffhunk://#diff-b260c26245dee56762776fe4acb6a5eb8656632da1718ef6e864577b3643ea8bR1-R77) [[12]](diffhunk://#diff-180e579beee1ab4b8ddfff6a8ecfa520041bcc866bae92022b5e7a1970315be3R101-R127) [[13]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05L43-R44) [[14]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R77) [[15]](diffhunk://#diff-7ae9d0e4b8004202428a42fe41b1f7c2841aff0be6e35ef25a2947b596b6cf05R14)